### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/xutil.js
+++ b/lib/xutil.js
@@ -20,7 +20,7 @@ const rimraf = require('rimraf');
 const moment = require('moment');
 const mkdirp = require('mkdirp');
 const lodash = require('lodash');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const detectPort = require('detect-port');
 
 var _ = lodash.merge({}, lodash);

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "lodash": "~3.10.1",
     "mkdirp": "~0.5.1",
     "moment": "~2.10.6",
-    "node-uuid": "~1.4.7",
-    "rimraf": "~2.5.0"
+    "rimraf": "~2.5.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "co-mocha": "^1.1.3",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.