### PR TITLE
chore: upgrade shelljs to fix circular dep warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "opn": "^5.1.0",
     "rimraf": "^2.5.4",
     "semver": "^5.4.1",
-    "shelljs": "^0.7.8",
+    "shelljs": "^0.8.4",
     "uuid": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently many macacajs tools show warnings like: 
```
(node:80707) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
```
We can fix it by upgrading shelljs to 0.8.4, see https://github.com/shelljs/shelljs/pull/973 .